### PR TITLE
fix(rack): implement optimistic update to prevent snap-back on drop

### DIFF
--- a/api/flex.ts
+++ b/api/flex.ts
@@ -1,7 +1,7 @@
 import { apiFetch } from "./client";
 import { flexImportResponseSchema, FlexImportResponse } from "@/types/flexTypes";
 import { pullsheetItemSchema, PullsheetItem } from "@/types/jobTypes";
-import { Side } from "@/types/rackDrawingTypes";
+import { Side, placedItemResponseSchema } from "@/types/rackDrawingTypes";
 import { z } from "zod";
 
 export async function importFlexUrl(url: string): Promise<FlexImportResponse> {
@@ -19,7 +19,7 @@ export async function movePlacedItem(
   startPosition: number,
   side: Side,
 ): Promise<void> {
-  return apiFetch(`/jobs/${jobId}/pullsheet-items/${itemId}/move`, z.void(), {
+  await apiFetch(`/jobs/${jobId}/pullsheet-items/${itemId}/move`, placedItemResponseSchema, {
     method: "PATCH",
     body: JSON.stringify({ startPosition, side }),
   });

--- a/hooks/usePullsheetItems.ts
+++ b/hooks/usePullsheetItems.ts
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getUnplacedItems, movePlacedItem } from "@/api/flex";
 import { queryKeys } from "@/api/queryKeys";
-import { Side } from "@/types/rackDrawingTypes";
+import { Side, RackDrawingWithItems } from "@/types/rackDrawingTypes";
+import { toast } from "sonner";
 
 export function useUnplacedItems(jobId: number) {
   return useQuery({
@@ -18,6 +19,39 @@ export function useMovePlacedItem(jobId: number, rackDrawingId: number) {
   return useMutation({
     mutationFn: ({ itemId, startPosition, side }: { itemId: number; startPosition: number; side: Side }) =>
       movePlacedItem(jobId, itemId, rackDrawingId, startPosition, side),
+    onMutate: async ({ itemId, startPosition, side }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.rackDrawings.byJob(jobId) });
+
+      const previousData = queryClient.getQueryData(queryKeys.rackDrawings.byJob(jobId));
+
+      queryClient.setQueryData<RackDrawingWithItems[]>(
+        queryKeys.rackDrawings.byJob(jobId),
+        (oldData) => {
+          if (!Array.isArray(oldData)) return oldData;
+
+          const racks = oldData as RackDrawingWithItems[];
+          return racks.map((rack) => ({
+            ...rack,
+            placedItems: rack.placedItems.map((item: typeof rack.placedItems[number]) =>
+              item.id === itemId
+                ? { ...item, startPosition, side }
+                : item
+            ),
+          }));
+        }
+      );
+
+      return { previousData };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(
+          queryKeys.rackDrawings.byJob(jobId),
+          context.previousData
+        );
+      }
+      toast.error("Failed to move item. Please try again.");
+    },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.rackDrawings.byJob(jobId) });
     },

--- a/types/rackDrawingTypes.ts
+++ b/types/rackDrawingTypes.ts
@@ -38,6 +38,22 @@ export const placedItemSchema = z.object({
 
 export type PlacedItem = z.infer<typeof placedItemSchema>;
 
+export const placedItemResponseSchema = placedItemSchema.extend({
+  jobId: z.number().int().positive(),
+  equipmentCatalogId: z.number().int().positive().nullable(),
+  genericEquipmentId: z.number().int().positive().nullable(),
+  rackDrawingId: z.number().int().positive(),
+  parentId: z.number().int().positive().nullable(),
+  quantity: z.number().int().positive(),
+  flexResourceId: z.string().nullable(),
+  flexSection: z.string(),
+  isFromPullsheet: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type PlacedItemResponse = z.infer<typeof placedItemResponseSchema>;
+
 export const rackDrawingWithItemsSchema = rackDrawingSchema.extend({
   placedItems: z.array(placedItemSchema).default([]),
 });


### PR DESCRIPTION
## Summary

Fixed issue where rack items would snap back to their original position after being dropped. Implemented optimistic UI updates that show the item moving immediately, with proper error handling and validation.

## Closes

Closes #9

## Changes by File

### Frontend - Types

**types/rackDrawingTypes.ts**
- Added `placedItemResponseSchema` extending `placedItemSchema` with full database fields (jobId, rackDrawingId, quantity, timestamps, etc.)
- Added `PlacedItemResponse` type inferred from the schema
- Ensures API responses validate correctly without throwing errors

### Frontend - Hooks

**hooks/usePullsheetItems.ts**
- Added `onMutate` callback to `useMovePlacedItem` mutation that:
  - Cancels pending refetches to prevent race conditions
  - Captures current cache state for rollback
  - Immediately updates cache with new item position (optimistic update)
- Added `onError` callback to rollback UI to previous state if mutation fails
- Shows error toast notification when move fails
- Eliminates lag/snap-back by updating UI before API request completes

### Frontend - API

**api/flex.ts**
- Updated `movePlacedItem` to import and use `placedItemResponseSchema` instead of `z.void()`
- Properly validates API response against full placed item structure
- Prevents false validation errors that were triggering the onError callback

## Testing Steps

- [ ] Run `npm run dev` to start the development server
- [ ] Navigate to a rack with placed items
- [ ] Drag an item from one position to another and drop it
- [ ] Verify the item stays in the dropped position immediately (no lag or snap-back)
- [ ] Refresh the page and verify the item is in the correct position (change persisted to backend)
- [ ] In DevTools Network tab, verify the PATCH request to `/pullsheet-items/{id}/move` succeeds with 200 response

## Notes

- The optimistic update provides immediate visual feedback to the user
- Error handling ensures the UI reverts if the backend rejects the move
- All changes are backward compatible - no breaking changes
- TypeScript validation is fully type-safe with no `any` types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Item placement changes now appear instantly without waiting for server confirmation.
  * Added error notifications when moves fail, with automatic restoration of the previous state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->