### PR TITLE
Fix inconsistent drag-and-drop behavior with rack items

### DIFF
--- a/components/rack/RackDrawing.tsx
+++ b/components/rack/RackDrawing.tsx
@@ -145,8 +145,8 @@ function RackColumn({
           }}
         />
       )}
-      {items.map((item, idx) => (
-        <DraggableRackItem key={idx} item={item} />
+      {items.map((item) => (
+        <DraggableRackItem key={item.id} item={item} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
Fixed issue #10 where some rack items would become unresponsive to dragging in an inconsistent, non-deterministic manner. The root cause was using array indices as React keys for dynamically rendered draggable items.

## Changes by File
- **components/rack/RackDrawing.tsx**: Changed `key={idx}` to `key={item.id}` in the DraggableRackItem map (line 149)

## Technical Details
When using array index as the React key for a dynamic list, removing/adding/reordering items causes indices to shift. This forces React to unmount and remount the DraggableRackItem components, which breaks the dnd-kit `useDraggable` hook's ref attachment.

By using the stable `item.id` as the key, each item maintains its identity across re-renders, ensuring the drag handler stays properly attached.

## Testing Steps
1. Open the rack drawing view with multiple items
2. Attempt to drag various items multiple times
3. Add/remove items from the rack using the normal placement workflow
4. Verify that all items remain consistently draggable before and after modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when reordering rack items in drag-and-drop operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->