### PR TITLE
feat: drag equipment from sidebar into rack to place items

### DIFF
--- a/api/flex.ts
+++ b/api/flex.ts
@@ -12,6 +12,23 @@ export async function getUnplacedItems(jobId: number): Promise<PullsheetItem[]> 
   return apiFetch(`/jobs/${jobId}/pullsheet-items/unplaced`, z.array(pullsheetItemSchema));
 }
 
+export async function placePullsheetItem(
+  jobId: number,
+  itemId: number,
+  rackDrawingId: number,
+  startPosition: number,
+  side: Side,
+): Promise<PullsheetItem> {
+  return apiFetch(
+    `/jobs/${jobId}/pullsheet-items/${itemId}/place`,
+    pullsheetItemSchema,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ rackDrawingId, startPosition, side }),
+    }
+  );
+}
+
 export async function movePlacedItem(
   jobId: number,
   itemId: number,
@@ -23,4 +40,21 @@ export async function movePlacedItem(
     method: "PATCH",
     body: JSON.stringify({ startPosition, side }),
   });
+}
+
+export async function placeGenericEquipment(
+  jobId: number,
+  genericEquipmentId: number,
+  rackDrawingId: number,
+  startPosition: number,
+  side: Side,
+): Promise<PullsheetItem> {
+  return apiFetch(
+    `/jobs/${jobId}/pullsheet-items/place-generic`,
+    pullsheetItemSchema,
+    {
+      method: "POST",
+      body: JSON.stringify({ genericEquipmentId, rackDrawingId, quantity: 1, startPosition, side }),
+    }
+  );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -110,7 +110,7 @@
   --rack-item-wireless: oklch(0.88 0.07 240);
   --rack-item-network: oklch(0.88 0.07 155);
   --rack-item-console: oklch(0.88 0.07 295);
-  --rack-item-generic: oklch(0.88 0 0);
+  --rack-item-generic: oklch(0.94 0 0);
   --rack-item-default: oklch(0.94 0 0);
   --rack-drop-target: oklch(75.006% 0.08342 226.976);
 }

--- a/app/job/[jobId]/page.tsx
+++ b/app/job/[jobId]/page.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { notFound } from "next/navigation";
-import EquipmentSidebar from "@/components/equipment/EquipmentSidebar";
-import RackDrawingsView from "@/components/rack/RackDrawingsView";
+import JobLayout from "@/components/job/JobLayout";
 import { getJob } from "@/api/jobs";
 
 interface JobPageProps {
@@ -39,17 +38,5 @@ export default async function JobPage({ params }: JobPageProps) {
     throw error;
   }
 
-  return (
-    <div className="flex h-screen overflow-hidden">
-      <EquipmentSidebar jobId={jobIdNum} />
-      <main className="flex-1 overflow-auto bg-background flex flex-col">
-        <header className="border-b border-border px-6 py-4">
-          <h1 className="text-2xl font-bold text-foreground">{job.name}</h1>
-        </header>
-        <div className="flex-1 p-6 overflow-auto">
-          <RackDrawingsView jobId={jobIdNum} tourShow={job.name} />
-        </div>
-      </main>
-    </div>
-  );
+  return <JobLayout jobId={jobIdNum} jobName={job.name} />;
 }

--- a/components/equipment/EquipmentSidebar.tsx
+++ b/components/equipment/EquipmentSidebar.tsx
@@ -4,86 +4,157 @@ import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useUnplacedItems } from "@/hooks/usePullsheetItems";
 import { useGenericEquipment } from "@/hooks/useGenericEquipment";
+import { useDraggable } from "@dnd-kit/react";
+import { PullsheetItem } from "@/types/jobTypes";
 
-// Shared interface for rendering both PullsheetItem and GenericEquipment
-interface EquipmentDisplayItem {
-  id: number;
+// A grouped row: N unplaced records of the same equipment type collapsed into one
+interface GroupedItem {
+  representativeId: number;
+  flexResourceId: string;
   name: string;
   displayName?: string | null;
   rackUnits: number;
-  quantity: number;
+  count: number;
   parentId?: number | null;
-  children?: EquipmentDisplayItem[];
+  children?: GroupedItem[];
+  sourceType: "pullsheet" | "generic";
+  // For generic items the representativeId is the genericEquipmentId
 }
 
 interface EquipmentSection {
   label: string;
-  items: EquipmentDisplayItem[];
+  items: GroupedItem[];
+}
+
+function DraggablePullsheetRow({
+  item,
+  depth,
+  isHighlighted,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  item: GroupedItem;
+  depth: number;
+  isHighlighted: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}) {
+  const { ref } = useDraggable({
+    id: `sidebar-pullsheet-${item.representativeId}`,
+    data: { rackUnits: item.rackUnits, itemId: item.representativeId },
+  });
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        paddingLeft: `${12 + depth * 16}px`,
+        ...(depth > 0 && {
+          borderLeft: "2px solid hsl(var(--primary) / 0.2)",
+        }),
+      }}
+      className={`flex items-center gap-2 py-1.5 mx-1 rounded cursor-grab text-sm text-foreground transition-colors group ${
+        isHighlighted ? "bg-primary/10" : "hover:bg-secondary/70"
+      }`}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <span className="flex-1">{item.displayName || item.name}</span>
+      <span className="text-[10px] text-muted-foreground font-mono">
+        x{item.count}
+      </span>
+      {item.rackUnits > 0 && (
+        <span className="text-[10px] text-muted-foreground font-mono">
+          {item.rackUnits}U
+        </span>
+      )}
+    </div>
+  );
+}
+
+function DraggableGenericRow({
+  item,
+  depth,
+  isHighlighted,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  item: GroupedItem;
+  depth: number;
+  isHighlighted: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}) {
+  const { ref } = useDraggable({
+    id: `sidebar-generic-${item.representativeId}`,
+    data: { rackUnits: item.rackUnits, genericEquipmentId: item.representativeId },
+  });
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        paddingLeft: `${12 + depth * 16}px`,
+        ...(depth > 0 && {
+          borderLeft: "2px solid hsl(var(--primary) / 0.2)",
+        }),
+      }}
+      className={`flex items-center gap-2 py-1.5 mx-1 rounded cursor-grab text-sm text-foreground transition-colors group ${
+        isHighlighted ? "bg-primary/10" : "hover:bg-secondary/70"
+      }`}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <span className="flex-1">{item.displayName || item.name}</span>
+      {item.rackUnits > 0 && (
+        <span className="text-[10px] text-muted-foreground font-mono">
+          {item.rackUnits}U
+        </span>
+      )}
+    </div>
+  );
 }
 
 function ItemRow({
   item,
   depth = 0,
   hoveredItemId,
-  hoveredItemParentId,
   onHoverChange,
 }: {
-  item: EquipmentDisplayItem;
+  item: GroupedItem;
   depth?: number;
-  hoveredItemId: number | null;
-  hoveredItemParentId: number | null;
-  onHoverChange: (itemId: number | null, parentId: number | null) => void;
+  hoveredItemId: string | null;
+  onHoverChange: (id: string | null) => void;
 }) {
-  const hasChildren = item.children && item.children.length > 0;
+  const rowId = `${item.sourceType}-${item.representativeId}`;
+  const parentRowId = item.parentId ? `${item.sourceType}-${item.parentId}` : null;
 
-  // Check if this item or any of its children/parents is hovered
-  const isRelatedToHovered = (hoveredId: number | null, hoveredParentId: number | null): boolean => {
-    if (!hoveredId) return false;
-    if (item.id === hoveredId) return true;
-    if (item.parentId === hoveredId) return true;
-    // Highlight siblings (items with same parent as hovered item)
-    if (hoveredParentId !== null && item.parentId === hoveredParentId) return true;
-    if (hasChildren) {
-      return item.children!.some((child) => child.id === hoveredId);
-    }
-    return false;
+  const isHighlighted =
+    hoveredItemId === rowId ||
+    (parentRowId !== null && hoveredItemId === parentRowId) ||
+    (item.children?.some((c) => `${c.sourceType}-${c.representativeId}` === hoveredItemId) ?? false);
+
+  const sharedProps = {
+    item,
+    depth,
+    isHighlighted,
+    onMouseEnter: () => onHoverChange(rowId),
+    onMouseLeave: () => onHoverChange(null),
   };
-
-  const isHighlighted = isRelatedToHovered(hoveredItemId, hoveredItemParentId);
 
   return (
     <>
-      <div
-        style={{
-          paddingLeft: `${12 + depth * 16}px`,
-          ...(depth > 0 && {
-            borderLeft: "2px solid hsl(var(--primary) / 0.2)",
-            borderRadius: "0",
-          }),
-        }}
-        className={`flex items-center gap-2 py-1.5 mx-1 rounded cursor-grab text-sm text-foreground transition-colors group ${
-          isHighlighted ? "bg-primary/10" : "hover:bg-secondary/70"
-        }`}
-        onMouseEnter={() => onHoverChange(item.id, item.parentId ?? null)}
-        onMouseLeave={() => onHoverChange(null, null)}
-      >
-        <span className="flex-1">{item.displayName || item.name}</span>
-        <span className="text-[10px] text-muted-foreground font-mono">
-          x{item.quantity}
-        </span>
-        {item.rackUnits > 0 && (
-          <span className="text-[10px] text-muted-foreground font-mono">
-            {item.rackUnits}U
-          </span>
-        )}
-      </div>
+      {item.sourceType === "pullsheet" ? (
+        <DraggablePullsheetRow {...sharedProps} />
+      ) : (
+        <DraggableGenericRow {...sharedProps} />
+      )}
       {item.children?.map((child) => (
         <ItemRow
-          key={child.id}
+          key={`${child.sourceType}-${child.representativeId}`}
           item={child}
           depth={depth + 1}
           hoveredItemId={hoveredItemId}
-          hoveredItemParentId={hoveredItemParentId}
           onHoverChange={onHoverChange}
         />
       ))}
@@ -93,8 +164,7 @@ function ItemRow({
 
 function SectionGroup({ section }: { section: EquipmentSection }) {
   const [open, setOpen] = useState(false);
-  const [hoveredItemId, setHoveredItemId] = useState<number | null>(null);
-  const [hoveredItemParentId, setHoveredItemParentId] = useState<number | null>(null);
+  const [hoveredItemId, setHoveredItemId] = useState<string | null>(null);
 
   return (
     <div>
@@ -117,20 +187,102 @@ function SectionGroup({ section }: { section: EquipmentSection }) {
         <div className="pb-1">
           {section.items.map((item) => (
             <ItemRow
-              key={item.id}
+              key={`${item.sourceType}-${item.representativeId}`}
               item={item}
               hoveredItemId={hoveredItemId}
-              hoveredItemParentId={hoveredItemParentId}
-              onHoverChange={(itemId, parentId) => {
-                setHoveredItemId(itemId);
-                setHoveredItemParentId(parentId);
-              }}
+              onHoverChange={setHoveredItemId}
             />
           ))}
         </div>
       )}
     </div>
   );
+}
+
+// Group pullsheet items by flexResourceId within each section, building a hierarchy
+function groupPullsheetItems(
+  items: PullsheetItem[],
+  showAllItems: boolean,
+): Map<string, GroupedItem[]> {
+  const grouped = new Map<string, GroupedItem[]>();
+
+  // Group all records by flexResourceId to get counts and representative IDs
+  const byFlexId = new Map<string, PullsheetItem[]>();
+  for (const item of items) {
+    const key = item.flexResourceId || item.name;
+    if (!byFlexId.has(key)) byFlexId.set(key, []);
+    byFlexId.get(key)!.push(item);
+  }
+
+  // Build a map of flexResourceId → GroupedItem (root items only) keyed by parentId
+  // We need to find root items and their children
+  const rootItems = items.filter((i) => !i.parentId && (showAllItems || i.rackUnits > 0));
+
+  // Group children by parentId's flexResourceId → representative parentId
+  // We need the representative (lowest id) of the parent group to look up parentId
+  const representativeByFlexId = new Map<string, number>();
+  for (const [flexId, group] of byFlexId) {
+    const sorted = [...group].sort((a, b) => a.id - b.id);
+    representativeByFlexId.set(flexId, sorted[0]!.id);
+  }
+
+  // Build GroupedItem for a given flexResourceId + items
+  const buildGroupedItem = (
+    flexId: string,
+    records: PullsheetItem[],
+    parentId: number | null,
+  ): GroupedItem => {
+    const sorted = [...records].sort((a, b) => a.id - b.id);
+    const rep = sorted[0]!;
+    return {
+      representativeId: rep.id,
+      flexResourceId: flexId,
+      name: rep.name,
+      displayName: rep.displayNameOverride,
+      rackUnits: rep.rackUnits,
+      count: records.length,
+      parentId,
+      sourceType: "pullsheet",
+      children: [],
+    };
+  };
+
+  // Track which flexIds we've already emitted as roots (to avoid duplicates)
+  const emittedRoots = new Set<string>();
+
+  for (const rootItem of rootItems) {
+    const flexId = rootItem.flexResourceId || rootItem.name;
+    if (emittedRoots.has(flexId)) continue;
+    emittedRoots.add(flexId);
+
+    const section = rootItem.flexSection;
+    if (!grouped.has(section)) grouped.set(section, []);
+
+    const records = byFlexId.get(flexId) ?? [rootItem];
+    const groupedItem = buildGroupedItem(flexId, records, null);
+
+    // Find children of this group (items whose parentId is one of the representative's records)
+    // Children link to the first/representative parent record
+    const repId = groupedItem.representativeId;
+    const childItems = items.filter((i) => i.parentId === repId);
+
+    if (childItems.length > 0) {
+      const childByFlexId = new Map<string, PullsheetItem[]>();
+      for (const child of childItems) {
+        const key = child.flexResourceId || child.name;
+        if (!childByFlexId.has(key)) childByFlexId.set(key, []);
+        childByFlexId.get(key)!.push(child);
+      }
+
+      for (const [childFlexId, childRecords] of childByFlexId) {
+        groupedItem.children!.push(buildGroupedItem(childFlexId, childRecords, repId));
+      }
+    }
+
+    grouped.get(section)!.push(groupedItem);
+  }
+
+  return grouped;
 }
 
 interface EquipmentSidebarProps {
@@ -146,85 +298,39 @@ export default function EquipmentSidebar({ jobId }: EquipmentSidebarProps) {
     error: genericError,
   } = useGenericEquipment();
 
-  // Log errors for debugging
   useEffect(() => {
-    if (error) {
-      console.log("Pullsheet items error:", error);
-    }
+    if (error) console.log("Pullsheet items error:", error);
   }, [error]);
 
   useEffect(() => {
-    if (genericError) {
-      console.log("Generic equipment error:", genericError);
-    }
+    if (genericError) console.log("Generic equipment error:", genericError);
   }, [genericError]);
 
-  // Build pullsheet items with parent-child hierarchy
-  const groupedPullsheetItems = new Map<string, EquipmentDisplayItem[]>();
-  if (pullsheetItems) {
-    // Map all items, track by ID
-    const itemMap = new Map<number, EquipmentDisplayItem>();
-    pullsheetItems.forEach((item) => {
-      itemMap.set(item.id, {
-        id: item.id,
-        name: item.name,
-        displayName: item.displayNameOverride,
-        rackUnits: item.rackUnits,
-        quantity: item.quantity,
-        parentId: item.parentId,
-        children: [],
-      });
-    });
-
-    // Assign children to parents
-    pullsheetItems.forEach((item) => {
-      if (item.parentId && itemMap.has(item.parentId)) {
-        const parent = itemMap.get(item.parentId);
-        const child = itemMap.get(item.id);
-        if (child) {
-          parent?.children?.push(child);
-        }
-      }
-    });
-
-    // Collect root items that pass the filter and group by flexSection
-    pullsheetItems.forEach((item) => {
-      if (!item.parentId && (showAllItems || item.rackUnits > 0)) {
-        const displayItem = itemMap.get(item.id);
-        if (displayItem) {
-          const section = item.flexSection;
-          if (!groupedPullsheetItems.has(section)) {
-            groupedPullsheetItems.set(section, []);
-          }
-          groupedPullsheetItems.get(section)?.push(displayItem);
-        }
-      }
-    });
-  }
+  const groupedPullsheetItems = pullsheetItems
+    ? groupPullsheetItems(pullsheetItems, showAllItems)
+    : new Map<string, GroupedItem[]>();
 
   const pullsheetSections: EquipmentSection[] = Array.from(
     groupedPullsheetItems.entries(),
   ).map(([label, items]) => ({ label, items }));
 
-  // Group generic items by category
-  const groupedGenericItems = new Map<string, EquipmentDisplayItem[]>();
+  // Generic items: always one per entry (no per-unit tracking needed)
+  const groupedGenericItems = new Map<string, GroupedItem[]>();
   if (genericEquipment) {
-    genericEquipment.forEach((item) => {
+    for (const item of genericEquipment) {
       if (!groupedGenericItems.has(item.category)) {
         groupedGenericItems.set(item.category, []);
       }
-      const items = groupedGenericItems.get(item.category);
-      if (items) {
-        // Map GenericEquipment to EquipmentDisplayItem
-        items.push({
-          id: item.id,
-          name: item.name,
-          displayName: item.displayName,
-          rackUnits: item.rackUnits,
-          quantity: 1,
-        });
-      }
-    });
+      groupedGenericItems.get(item.category)!.push({
+        representativeId: item.id,
+        flexResourceId: String(item.id),
+        name: item.name,
+        displayName: item.displayName,
+        rackUnits: item.rackUnits,
+        count: 1,
+        sourceType: "generic",
+      });
+    }
   }
 
   const genericSections: EquipmentSection[] = Array.from(

--- a/components/job/JobLayout.tsx
+++ b/components/job/JobLayout.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { DragDropProvider } from "@dnd-kit/react";
+import EquipmentSidebar from "@/components/equipment/EquipmentSidebar";
+import RackDrawingsView from "@/components/rack/RackDrawingsView";
+import { useRackDrawings } from "@/hooks/useRackDrawings";
+import { usePlacePullsheetItem, useMovePlacedItem, usePlaceGenericEquipment } from "@/hooks/usePullsheetItems";
+import { hasOverlap } from "@/components/rack/rackUtils";
+import type { RackItem } from "@/components/rack/RackDrawing";
+import type { Side } from "@/types/rackDrawingTypes";
+
+interface JobLayoutProps {
+  jobId: number;
+  jobName: string;
+}
+
+interface DragState {
+  draggedItemId: number | null;
+  draggedItemSize: number | null;
+  dropId: string | null;
+}
+
+export default function JobLayout({ jobId, jobName }: JobLayoutProps) {
+  const [activeRackId, setActiveRackId] = useState<number | null>(null);
+  const [dragState, setDragState] = useState<DragState>({
+    draggedItemId: null,
+    draggedItemSize: null,
+    dropId: null,
+  });
+
+  const { data: racks } = useRackDrawings(jobId);
+  const placePullsheetItemMutation = usePlacePullsheetItem(jobId);
+  const placeGenericEquipmentMutation = usePlaceGenericEquipment(jobId);
+  const movePlacedItemMutation = useMovePlacedItem(jobId, activeRackId ?? 0);
+
+  const sortedRacks = useMemo(() => {
+    if (!racks) return [];
+    return [...racks].sort((a, b) => a.displayOrder - b.displayOrder);
+  }, [racks]);
+
+  const displayRackId = activeRackId ?? sortedRacks[0]?.id;
+  const activeRack = sortedRacks.find((r) => r.id === displayRackId);
+
+  // Flat list of rack items with positions — used for overlap detection on drag
+  const allRackItems = useMemo((): RackItem[] => {
+    if (!activeRack) return [];
+    return activeRack.placedItems
+      .filter((item) => item.rackUnits > 0 && item.startPosition !== null)
+      .map((item) => ({
+        id: item.id,
+        name: item.displayNameOverride ?? item.name,
+        startU: item.startPosition!,
+        endU: item.startPosition! + item.rackUnits - 1,
+        side: (item.side ?? "FRONT") as Side,
+      }));
+  }, [activeRack]);
+
+  return (
+    <DragDropProvider
+      onDragOver={({ operation }) => {
+        const sourceId = operation.source?.id;
+        const targetId = (operation.target?.id as string) ?? null;
+
+        if (typeof sourceId === "string" && sourceId.startsWith("sidebar-")) {
+          const data = operation.source?.data as { rackUnits: number };
+          setDragState({
+            draggedItemId: null,
+            draggedItemSize: data?.rackUnits ?? null,
+            dropId: targetId,
+          });
+        } else {
+          const numId = sourceId as number;
+          const placedItem = activeRack?.placedItems.find((i) => i.id === numId);
+          setDragState({
+            draggedItemId: numId ?? null,
+            draggedItemSize: placedItem?.rackUnits ?? null,
+            dropId: targetId,
+          });
+        }
+      }}
+      onDragEnd={({ operation }) => {
+        const sourceId = operation.source?.id;
+        const dropId = (operation.target?.id as string) ?? null;
+
+        if (sourceId && dropId && dragState.draggedItemSize !== null && activeRack) {
+          const [sideStr, uStr] = dropId.split("-");
+          const side = sideStr as Side;
+          let startPosition = parseInt(uStr);
+
+          const maxValidPosition = activeRack.totalSpaces - dragState.draggedItemSize + 1;
+          if (startPosition > maxValidPosition) {
+            startPosition = maxValidPosition;
+          }
+          const endPosition = startPosition + dragState.draggedItemSize - 1;
+          const sideItems = allRackItems.filter((item) => item.side === side);
+
+          if (typeof sourceId === "string" && sourceId.startsWith("sidebar-pullsheet-")) {
+            const itemId = parseInt(sourceId.replace("sidebar-pullsheet-", ""));
+            if (!hasOverlap(startPosition, endPosition, sideItems, null)) {
+              placePullsheetItemMutation.mutate({ itemId, rackDrawingId: activeRack.id, startPosition, side });
+            }
+          } else if (typeof sourceId === "string" && sourceId.startsWith("sidebar-generic-")) {
+            const genericEquipmentId = parseInt(sourceId.replace("sidebar-generic-", ""));
+            if (!hasOverlap(startPosition, endPosition, sideItems, null)) {
+              placeGenericEquipmentMutation.mutate({ genericEquipmentId, rackDrawingId: activeRack.id, startPosition, side });
+            }
+          } else {
+            const itemId = sourceId as number;
+            if (!hasOverlap(startPosition, endPosition, sideItems, itemId)) {
+              movePlacedItemMutation.mutate({ itemId, startPosition, side });
+            }
+          }
+        }
+
+        setDragState({ draggedItemId: null, draggedItemSize: null, dropId: null });
+      }}
+    >
+      <div className="flex h-screen overflow-hidden">
+        <EquipmentSidebar jobId={jobId} />
+        <main className="flex-1 overflow-auto bg-background flex flex-col">
+          <header className="border-b border-border px-6 py-4">
+            <h1 className="text-2xl font-bold text-foreground">{jobName}</h1>
+          </header>
+          <div className="flex-1 p-6 overflow-auto">
+            <RackDrawingsView
+              jobId={jobId}
+              tourShow={jobName}
+              activeRackId={activeRackId}
+              onActiveRackChange={setActiveRackId}
+              draggedItemSize={dragState.draggedItemSize}
+              draggedItemId={dragState.draggedItemId}
+              hoveredDropId={dragState.dropId}
+            />
+          </div>
+        </main>
+      </div>
+    </DragDropProvider>
+  );
+}

--- a/components/rack/RackDrawingsView.tsx
+++ b/components/rack/RackDrawingsView.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import { useRackDrawings, useUpdateRackName } from "@/hooks/useRackDrawings";
 import { PlacedItem } from "@/types/rackDrawingTypes";
 import RackDrawing, { RackItem } from "./RackDrawing";
 import { Button } from "@/components/ui/button";
-import { DragDropProvider } from "@dnd-kit/react";
 import type { Side } from "@/types/rackDrawingTypes";
-import { useMovePlacedItem } from "@/hooks/usePullsheetItems";
-import { hasOverlap } from "./rackUtils";
+
 interface RackDrawingsViewProps {
   jobId: number;
   tourShow: string;
+  activeRackId: number | null;
+  onActiveRackChange: (id: number) => void;
+  draggedItemSize: number | null;
+  draggedItemId: number | null;
+  hoveredDropId: string | null;
 }
 
 function toRackItem(
@@ -52,7 +55,6 @@ function transformItemsWithPositioning(
   const placed: RackItem[] = [];
   const unplaced: Array<{ item: PlacedItem; position: number }> = [];
 
-  // Separate placed from unplaced and calculate unplaced positions
   let currentUnplacedPos = 1;
   for (const item of items) {
     const side = item.side ?? "FRONT";
@@ -66,7 +68,6 @@ function transformItemsWithPositioning(
     }
   }
 
-  // Convert unplaced items using calculated positions
   const unplacedRackItems = unplaced.map(({ item, position }) =>
     toRackItem(item, position, defaultSide),
   );
@@ -77,15 +78,14 @@ function transformItemsWithPositioning(
 export default function RackDrawingsView({
   jobId,
   tourShow,
+  activeRackId,
+  onActiveRackChange,
+  draggedItemSize,
+  draggedItemId,
+  hoveredDropId,
 }: RackDrawingsViewProps) {
   const { data: racks, isLoading, error } = useRackDrawings(jobId);
   const updateRackNameMutation = useUpdateRackName(jobId);
-  const [activeRackId, setActiveRackId] = useState<number | null>(null);
-  const [dragState, setDragState] = useState<{
-    itemId: number | null;
-    dropId: string | null;
-  }>({ itemId: null, dropId: null });
-  const movePlacedItemMutation = useMovePlacedItem(jobId, activeRackId ?? 0);
 
   const sortedRacks = useMemo(() => {
     if (!racks) return [];
@@ -117,7 +117,6 @@ export default function RackDrawingsView({
     );
   }
 
-  // Use first rack if activeRackId not set
   const displayRackId = activeRackId ?? sortedRacks[0]?.id;
   const activeRack = sortedRacks.find((r) => r.id === displayRackId);
 
@@ -125,7 +124,6 @@ export default function RackDrawingsView({
     return null;
   }
 
-  // Filter out items with 0 RU (cables, docs, etc.) - they shouldn't render in the rack
   const itemsWithRU = activeRack.placedItems.filter(
     (item) => item.rackUnits > 0,
   );
@@ -140,103 +138,55 @@ export default function RackDrawingsView({
     "BACK",
     activeRack.isDoubleWide,
   );
-  const frontLeftItems = frontItems.filter(
-    (item) => item.side === "FRONT_LEFT",
-  );
-  const frontRightItems = frontItems.filter(
-    (item) => item.side === "FRONT_RIGHT",
-  );
+  const frontLeftItems = frontItems.filter((item) => item.side === "FRONT_LEFT");
+  const frontRightItems = frontItems.filter((item) => item.side === "FRONT_RIGHT");
   const backLeftItems = backItems.filter((item) => item.side === "BACK_LEFT");
   const backRightItems = backItems.filter((item) => item.side === "BACK_RIGHT");
-  const allItems = [...frontItems, ...backItems];
-  const draggedItem = allItems.find((item) => item.id === dragState.itemId);
-  const draggedItemSize = draggedItem
-    ? draggedItem.endU - draggedItem.startU + 1
-    : null;
 
-  const [hoveredSide, hoveredUStr] = dragState.dropId?.split("-") ?? [];
+  const [hoveredSide, hoveredUStr] = hoveredDropId?.split("-") ?? [];
   const hoveredU = hoveredUStr ? parseInt(hoveredUStr) : null;
 
   return (
-    <DragDropProvider
-      onDragOver={({ operation }) => {
-        setDragState({
-          itemId: (operation.source?.id as number) ?? null,
-          dropId: (operation.target?.id as string) ?? null,
-        });
-      }}
-      onDragEnd={({ operation }) => {
-        const itemId = operation.source?.id as number;
-        const dropId = operation.target?.id as string;
+    <div className="space-y-6">
+      {sortedRacks.length > 1 && (
+        <div className="flex gap-2 border-b border-border">
+          {sortedRacks.map((rack) => (
+            <Button
+              key={rack.id}
+              variant={displayRackId === rack.id ? "default" : "ghost"}
+              onClick={() => onActiveRackChange(rack.id)}
+              className="rounded-b-none"
+            >
+              {rack.name}
+            </Button>
+          ))}
+        </div>
+      )}
 
-        if (itemId && dropId && draggedItemSize !== null) {
-          const [side, uStr] = dropId.split("-");
-          let startPosition = parseInt(uStr);
-
-          // Prevent item from extending beyond rack boundary
-          const maxValidPosition = activeRack.totalSpaces - draggedItemSize + 1;
-          if (startPosition > maxValidPosition) {
-            startPosition = maxValidPosition;
-          }
-
-          const endPosition = startPosition + draggedItemSize - 1;
-          const sideItems = allItems.filter((item) => item.side === side);
-
-          if (!hasOverlap(startPosition, endPosition, sideItems, itemId)) {
-            movePlacedItemMutation.mutate({
-              itemId,
-              startPosition,
-              side: side as Side,
-            });
-          }
+      <RackDrawing
+        name={activeRack.name}
+        totalSpaces={activeRack.totalSpaces}
+        isDoubleWide={activeRack.isDoubleWide}
+        tourShow={tourShow}
+        frontItems={frontItems}
+        backItems={backItems}
+        frontLeftItems={frontLeftItems}
+        frontRightItems={frontRightItems}
+        backLeftItems={backLeftItems}
+        backRightItems={backRightItems}
+        draggedItemSize={draggedItemSize}
+        draggedItemId={draggedItemId}
+        hoveredU={hoveredU}
+        hoveredSide={(hoveredSide as Side) ?? null}
+        notes={activeRack.notes ?? undefined}
+        rackId={activeRack.id}
+        onNameChange={(newName) =>
+          updateRackNameMutation.mutateAsync({
+            rackId: activeRack.id,
+            name: newName,
+          })
         }
-
-        setDragState({ itemId: null, dropId: null });
-      }}
-    >
-      <div className="space-y-6">
-        {/* Tabs */}
-        {sortedRacks.length > 1 && (
-          <div className="flex gap-2 border-b border-border">
-            {sortedRacks.map((rack) => (
-              <Button
-                key={rack.id}
-                variant={displayRackId === rack.id ? "default" : "ghost"}
-                onClick={() => setActiveRackId(rack.id)}
-                className="rounded-b-none"
-              >
-                {rack.name}
-              </Button>
-            ))}
-          </div>
-        )}
-
-        {/* Rack Drawing */}
-        <RackDrawing
-          name={activeRack.name}
-          totalSpaces={activeRack.totalSpaces}
-          isDoubleWide={activeRack.isDoubleWide}
-          tourShow={tourShow}
-          frontItems={frontItems}
-          backItems={backItems}
-          frontLeftItems={frontLeftItems}
-          frontRightItems={frontRightItems}
-          backLeftItems={backLeftItems}
-          backRightItems={backRightItems}
-          draggedItemSize={draggedItemSize}
-          draggedItemId={dragState.itemId}
-          hoveredU={hoveredU}
-          hoveredSide={(hoveredSide as Side) ?? null}
-          notes={activeRack.notes ?? undefined}
-          rackId={activeRack.id}
-          onNameChange={(newName) =>
-            updateRackNameMutation.mutateAsync({
-              rackId: activeRack.id,
-              name: newName,
-            })
-          }
-        />
-      </div>
-    </DragDropProvider>
+      />
+    </div>
   );
 }

--- a/hooks/usePullsheetItems.ts
+++ b/hooks/usePullsheetItems.ts
@@ -1,7 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getUnplacedItems, movePlacedItem } from "@/api/flex";
+import { getUnplacedItems, movePlacedItem, placePullsheetItem, placeGenericEquipment } from "@/api/flex";
 import { queryKeys } from "@/api/queryKeys";
 import { Side, RackDrawingWithItems } from "@/types/rackDrawingTypes";
+import { PullsheetItem } from "@/types/jobTypes";
+import { GenericEquipment } from "@/types/genericEquipmentTypes";
 import { toast } from "sonner";
 
 export function useUnplacedItems(jobId: number) {
@@ -13,9 +15,77 @@ export function useUnplacedItems(jobId: number) {
   });
 }
 
+export function usePlacePullsheetItem(jobId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ itemId, rackDrawingId, startPosition, side }: { itemId: number; rackDrawingId: number; startPosition: number; side: Side }) =>
+      placePullsheetItem(jobId, itemId, rackDrawingId, startPosition, side),
+    onMutate: async ({ itemId, rackDrawingId, startPosition, side }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.pullsheetItems.unplaced(jobId) });
+      await queryClient.cancelQueries({ queryKey: queryKeys.rackDrawings.byJob(jobId) });
+
+      const previousUnplaced = queryClient.getQueryData(queryKeys.pullsheetItems.unplaced(jobId));
+      const previousRacks = queryClient.getQueryData(queryKeys.rackDrawings.byJob(jobId));
+
+      const unplacedItems = queryClient.getQueryData<PullsheetItem[]>(queryKeys.pullsheetItems.unplaced(jobId));
+      const item = unplacedItems?.find((i) => i.id === itemId);
+
+      // Remove placed item and its direct children from unplaced list
+      queryClient.setQueryData<PullsheetItem[]>(
+        queryKeys.pullsheetItems.unplaced(jobId),
+        (old) => old?.filter((i) => i.id !== itemId && i.parentId !== itemId) ?? []
+      );
+
+      if (item) {
+        queryClient.setQueryData<RackDrawingWithItems[]>(
+          queryKeys.rackDrawings.byJob(jobId),
+          (old) => {
+            if (!Array.isArray(old)) return old;
+            return old.map((rack) =>
+              rack.id === rackDrawingId
+                ? {
+                    ...rack,
+                    placedItems: [
+                      ...rack.placedItems,
+                      {
+                        id: item.id,
+                        name: item.name,
+                        displayNameOverride: item.displayNameOverride ?? null,
+                        rackUnits: item.rackUnits,
+                        side,
+                        startPosition,
+                        category: null,
+                      },
+                    ],
+                  }
+                : rack
+            );
+          }
+        );
+      }
+
+      return { previousUnplaced, previousRacks };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousUnplaced) {
+        queryClient.setQueryData(queryKeys.pullsheetItems.unplaced(jobId), context.previousUnplaced);
+      }
+      if (context?.previousRacks) {
+        queryClient.setQueryData(queryKeys.rackDrawings.byJob(jobId), context.previousRacks);
+      }
+      toast.error("Failed to place item. Please try again.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.pullsheetItems.unplaced(jobId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.rackDrawings.byJob(jobId) });
+    },
+  });
+}
+
 export function useMovePlacedItem(jobId: number, rackDrawingId: number) {
   const queryClient = useQueryClient();
-  
+
   return useMutation({
     mutationFn: ({ itemId, startPosition, side }: { itemId: number; startPosition: number; side: Side }) =>
       movePlacedItem(jobId, itemId, rackDrawingId, startPosition, side),
@@ -51,6 +121,62 @@ export function useMovePlacedItem(jobId: number, rackDrawingId: number) {
         );
       }
       toast.error("Failed to move item. Please try again.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.rackDrawings.byJob(jobId) });
+    },
+  });
+}
+
+export function usePlaceGenericEquipment(jobId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ genericEquipmentId, rackDrawingId, startPosition, side }: { genericEquipmentId: number; rackDrawingId: number; startPosition: number; side: Side }) =>
+      placeGenericEquipment(jobId, genericEquipmentId, rackDrawingId, startPosition, side),
+    onMutate: async ({ genericEquipmentId, rackDrawingId, startPosition, side }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.rackDrawings.byJob(jobId) });
+
+      const previousRacks = queryClient.getQueryData(queryKeys.rackDrawings.byJob(jobId));
+
+      const genericItems = queryClient.getQueryData<GenericEquipment[]>(queryKeys.genericEquipment.all);
+      const item = genericItems?.find((i) => i.id === genericEquipmentId);
+
+      if (item) {
+        queryClient.setQueryData<RackDrawingWithItems[]>(
+          queryKeys.rackDrawings.byJob(jobId),
+          (old) => {
+            if (!Array.isArray(old)) return old;
+            return old.map((rack) =>
+              rack.id === rackDrawingId
+                ? {
+                    ...rack,
+                    placedItems: [
+                      ...rack.placedItems,
+                      {
+                        id: -Date.now(),
+                        name: item.name,
+                        displayNameOverride: item.displayName ?? null,
+                        rackUnits: item.rackUnits,
+                        side,
+                        startPosition,
+                        category: "generic",
+                      },
+                    ],
+                  }
+                : rack
+            );
+          }
+        );
+      }
+
+      return { previousRacks };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousRacks) {
+        queryClient.setQueryData(queryKeys.rackDrawings.byJob(jobId), context.previousRacks);
+      }
+      toast.error("Failed to place item. Please try again.");
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.rackDrawings.byJob(jobId) });


### PR DESCRIPTION
Closes #19

## Summary

- Sidebar items are now draggable into rack slots using `@dnd-kit/react`
- `DragDropProvider` lifted to a new `JobLayout` client component so it wraps both the sidebar and the rack
- Pullsheet items are grouped by type (showing a count badge); dragging places one unit and decrements the count
- Generic equipment (blank panels, etc.) can also be dragged in
- Optimistic cache updates eliminate the post-drop flash — item appears in the rack and disappears from the sidebar instantly
- Overlap detection and boundary clamping apply the same way as in-rack moves

## Changes by File

| File | Change |
|---|---|
| `components/job/JobLayout.tsx` | **New** — client boundary owning `DragDropProvider`, `activeRackId`, drag state, and all placement mutations |
| `app/job/[jobId]/page.tsx` | Replaced inline layout with `<JobLayout>` |
| `components/rack/RackDrawingsView.tsx` | Removed `DragDropProvider` and internal drag state; now prop-driven |
| `components/equipment/EquipmentSidebar.tsx` | Grouped items by `flexResourceId` with count badge; added `DraggablePullsheetRow` / `DraggableGenericRow` |
| `api/flex.ts` | Added `placePullsheetItem` and `placeGenericEquipment` API functions |
| `hooks/usePullsheetItems.ts` | Added `usePlacePullsheetItem` and `usePlaceGenericEquipment` with `onMutate` optimistic updates |
| `app/globals.css` | Fixed `--rack-item-generic` color to match default |

## Testing Steps

- [ ] Drag a pullsheet item from the sidebar into an empty rack slot — item appears in rack, sidebar count decrements
- [ ] Drag a qty > 1 item — count decrements from N to N−1, remaining units still show
- [ ] Drag a generic item (e.g. Blank Panel) into the rack — appears with correct background
- [ ] Drag into an occupied slot — no placement, red preview shown
- [ ] Drag near the bottom of the rack — boundary clamping prevents overflow
- [ ] Move an already-placed rack item — existing repositioning still works
- [ ] Switch rack tabs, drop onto the active rack — correct rack receives the item
- [ ] Trigger a network failure — item snaps back (optimistic rollback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drag-and-drop placement of pullsheet items into racks
  * Drag-and-drop placement of generic equipment into racks
  * Equipment items now grouped for improved sidebar organization

* **Improvements**
  * Updated visual styling for rack item displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->