### PR TITLE
fix: reduce rack row height to improve viewport fit

### DIFF
--- a/components/rack/RackDrawing.tsx
+++ b/components/rack/RackDrawing.tsx
@@ -40,7 +40,7 @@ export interface RackDrawingProps {
   onNameChange?: (newName: string) => Promise<unknown>;
 }
 
-const ROW_HEIGHT = 32;
+const ROW_HEIGHT = 28;
 
 const categoryColors: Record<string, string> = {
   power: "bg-rack-item-power",


### PR DESCRIPTION
Closes #11

## Summary

- Reduces `ROW_HEIGHT` from 32px to 28px in `RackDrawing.tsx`
- A 30U rack body goes from 960px → 840px, reducing the need to scroll on typical viewports

## Testing Steps

- [ ] Open a job with a tall rack (20U+) and verify less vertical scrolling is needed
- [ ] Confirm item labels, U numbers, and drag-and-drop still work correctly at the smaller row height