### PR TITLE
fix/feat: rack item display improvements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -157,7 +157,7 @@
   --rack-item-wireless: oklch(0.32 0.08 240);
   --rack-item-network: oklch(0.32 0.08 155);
   --rack-item-console: oklch(0.32 0.08 295);
-  --rack-item-generic: oklch(0.32 0 0);
+  --rack-item-generic: oklch(0.28 0 0);
   --rack-item-default: oklch(0.28 0 0);
   --rack-drop-target: oklch(0.35 0.1 240);
 }

--- a/components/rack/RackDrawing.tsx
+++ b/components/rack/RackDrawing.tsx
@@ -18,6 +18,7 @@ export interface RackItem {
     | "console"
     | "generic"
     | "default";
+  children?: { name: string; count: number }[];
 }
 
 export interface RackDrawingProps {
@@ -82,7 +83,7 @@ function DraggableRackItem({ item }: { item: RackItem }) {
   return (
     <div
       ref={ref}
-      className={`absolute ${colorClass} border border-foreground/30 flex items-center justify-center text-sm font-medium text-foreground/90 z-10`}
+      className={`absolute ${colorClass} border border-foreground/30 flex flex-col items-center justify-center text-center text-sm font-medium text-foreground/90 z-10 px-2 overflow-hidden`}
       style={{
         top: (item.startU - 1) * ROW_HEIGHT,
         height: span * ROW_HEIGHT,
@@ -93,6 +94,13 @@ function DraggableRackItem({ item }: { item: RackItem }) {
       <span className={item.italic ? "italic text-muted-foreground" : ""}>
         {item.name}
       </span>
+      {item.children && item.children.length > 0 && (
+        <div className="mt-0.5 text-[10px] font-normal text-foreground/55 leading-tight">
+          {item.children.map((child) => (
+            <div key={child.name}>{child.name} ×{child.count}</div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/rack/RackDrawingsView.tsx
+++ b/components/rack/RackDrawingsView.tsx
@@ -124,20 +124,39 @@ export default function RackDrawingsView({
     return null;
   }
 
+  // Build children map: parentId → grouped { name, count }[]
+  const childrenByParentId = new Map<number, { name: string; count: number }[]>();
+  for (const item of activeRack.placedItems) {
+    if (item.parentId == null) continue;
+    const childName = item.displayNameOverride ?? item.name;
+    const existing = childrenByParentId.get(item.parentId) ?? [];
+    const found = existing.find((c) => c.name === childName);
+    if (found) found.count++;
+    else existing.push({ name: childName, count: 1 });
+    childrenByParentId.set(item.parentId, existing);
+  }
+
+  // Only top-level items (no parentId) with rack space are rendered directly
   const itemsWithRU = activeRack.placedItems.filter(
-    (item) => item.rackUnits > 0,
+    (item) => item.rackUnits > 0 && item.parentId == null,
   );
 
-  const frontItems = transformItemsWithPositioning(
+  const attachChildren = (items: RackItem[]) =>
+    items.map((item) => ({
+      ...item,
+      children: childrenByParentId.get(item.id),
+    }));
+
+  const frontItems = attachChildren(transformItemsWithPositioning(
     itemsWithRU,
     "FRONT",
     activeRack.isDoubleWide,
-  );
-  const backItems = transformItemsWithPositioning(
+  ));
+  const backItems = attachChildren(transformItemsWithPositioning(
     itemsWithRU,
     "BACK",
     activeRack.isDoubleWide,
-  );
+  ));
   const frontLeftItems = frontItems.filter((item) => item.side === "FRONT_LEFT");
   const frontRightItems = frontItems.filter((item) => item.side === "FRONT_RIGHT");
   const backLeftItems = backItems.filter((item) => item.side === "BACK_LEFT");

--- a/types/rackDrawingTypes.ts
+++ b/types/rackDrawingTypes.ts
@@ -33,6 +33,7 @@ export const placedItemSchema = z.object({
   rackUnits: z.number().int().min(0),
   side: sideSchema.nullish(),
   startPosition: z.number().int().min(1).nullish(),
+  parentId: z.number().int().positive().nullable(),
   category: z.string().nullish(),
 });
 


### PR DESCRIPTION
## Summary

- Centered text on placed rack items — long names now wrap centered instead of left-aligned
- Fixed generic item dark mode background color (was `oklch(0.32)`, now matches default at `oklch(0.28)`)
- Child equipment now appears beneath its parent item in the rack as small muted text with counts (e.g. `Input Card ×4`) — useful for complex equipment like DiGiCo frames with I/O cards

## Changes by File

| File | Change |
|---|---|
| `app/globals.css` | Fixed `--rack-item-generic` dark mode value to match `--rack-item-default` |
| `components/rack/RackDrawing.tsx` | Added `text-center px-2 flex-col overflow-hidden` to item container; added `children` field to `RackItem`; renders child list below item name |
| `types/rackDrawingTypes.ts` | Added `parentId` to `placedItemSchema` |
| `components/rack/RackDrawingsView.tsx` | Builds children map from placed items with `parentId`; filters child items out of top-level rendering; attaches grouped children to parent `RackItem`s |

> **Note:** requires the backend `rackDrawingController.ts` change (adding `parentId` to the Prisma select and response) to be deployed for children to appear.

## Testing Steps

- [ ] Rack items with long names display centered text
- [ ] Generic items match the default background color in dark mode
- [ ] A placed parent item with children shows child names + counts beneath it
- [ ] Items without children are unaffected